### PR TITLE
Update wg-amp4email membership

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@
 Facilitator: [@choumx](https://github.com/choumx)
 
 # Members
-- [@choumx](https://github.com/choumx) - William Chou (Facilitator)
-- [@jasti](https://github.com/jasti) - Vamsee Jasti
-- [@fstanis](https://github.com/fstanis) - Filip Stanis
 - [@cathyma123](https://github.com/cathyma123) - Cathy Ma
+- [@choumx](https://github.com/choumx) - William Chou (Facilitator)
+- [@fstanis](https://github.com/fstanis) - Filip Stanis
+- [@jasti](https://github.com/jasti) - Vamsee Jasti
+- [@johnbarr](https://github.com/johnbarr) - John Barr
 - [@kaewka](https://github.com/kaewka) - Thanawat Kaewka
 - [@latrekc](https://github.com/latrekc) - Stanislav Tugovikov
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Facilitator: [@choumx](https://github.com/choumx)
 # Members
 - [@choumx](https://github.com/choumx) - William Chou (Facilitator)
 - [@jasti](https://github.com/jasti) - Vamsee Jasti
+- [@fstanis](https://github.com/fstanis) - Filip Stanis
+- [@cathyma123](https://github.com/cathyma123) - Cathy Ma
+- [@kaewka](https://github.com/kaewka) - Thanawat Kaewka
+- [@latrekc](https://github.com/latrekc) - Stanislav Tugovikov
 
 Github team https://github.com/orgs/ampproject/teams/wg-amp4email also includes AMP for Email WG members.
 


### PR DESCRIPTION
Adds @fstanis (Google DevRel), @cathyma123 (Yahoo! Mail), @kaewka (Outlook), @latrekc (Mail.Ru), and @johnbarr (Gmail) to wg-amp4email.

@cathyma123, @kaewka and @johnbarr still need to join the ampproject organization to be added to the [wg-amp4email GitHub team](https://github.com/orgs/ampproject/teams/wg-amp4email). Please [fill out this form](https://goo.gl/forms/T65peVtfQfEoDWeD3).